### PR TITLE
Update info message finish script (#231)

### DIFF
--- a/spotify/rootfs/etc/services.d/spotifyd/finish
+++ b/spotify/rootfs/etc/services.d/spotifyd/finish
@@ -8,4 +8,4 @@ if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
   /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "spotifyd stoped, restarting..."
+bashio::log.info "spotifyd stopped."


### PR DESCRIPTION
Update info message when stopping the addon-on.

Fixes: #231

# Proposed Changes

Fixed the typo and removed the misleading "restarting" part.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
